### PR TITLE
Add config file to fileintegrity ignore list

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,6 @@
+<?php
+return array(
+    'fileintegrity.ignore' => DI\add(array(
+        'config/IntranetGeoIP.data.php',
+    ))
+);


### PR DESCRIPTION
Add "config/IntranetGeoIP.data.php" to the FileIntegrity check's ignore list.  This quiets the warning on the System Check page.